### PR TITLE
docs: reposition README for 2026 maintenance restart

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,27 @@
+# Contributing
+
+Thank you for helping improve this educational Apollo perception port.
+
+## Before you start
+
+- Read [ROADMAP.md](ROADMAP.md) and [README.md](README.md#known-limitations)
+- Check [open issues](https://github.com/cedricxie/apollo_perception_ros/issues)
+- Prefer Docker-based reproduction when possible
+
+## Ways to contribute
+
+1. **Documentation** — environment notes, bag setup, troubleshooting
+2. **Issue triage** — reproduction steps, logs, hardware details
+3. **Small fixes** — broken links, launch file parameters, doc corrections
+4. **Sensor adapters** — community integrations (discuss in an issue first)
+
+## Pull requests
+
+- One logical change per PR
+- Include reproduction steps or doc preview
+- Do not commit large binary model files without discussion
+
+## Code of conduct
+
+Be respectful. Many issue reporters are students encountering legacy tooling for
+the first time.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Apollo Perception Standalone in ROS
 
+> **Status (2026):** Maintenance restarted. This project ports parts of Apollo 3.0
+> perception into a standard ROS workflow. Original Apollo code is licensed under
+> Apache-2.0. See [LICENSE](LICENSE) and [NOTICE](NOTICE).
+
 [Apollo](https://github.com/ApolloAuto/apollo) is the most mature and sophisticated autonomous driving platform that is open source right now. 
 
 However, there are some limitations.
@@ -27,6 +31,36 @@ I myself find learning Apollo's approach in perception very beneficial to helpin
 
 **All contributions are welcome!!** There are so many things that can be improved. Please raise issues and/or make pull requests if you would like to work on it too. Thank you.
 
+## Current status
+
+This repository is a **historical and educational ROS port** of Apollo 3.0
+perception. It is actively maintained again as of 2026, with a focus on
+documentation, issue triage, license clarity, and reproducibility guidance.
+
+It is **not** a production autonomous driving stack.
+
+## Who is this for?
+
+- Students and researchers learning Apollo-style perception architecture
+- Developers who want to experiment with LiDAR / camera / fusion pipelines in ROS
+- Maintainers adapting legacy Apollo perception code to teaching labs or simulators
+
+## Known limitations
+
+- Requires a legacy software stack (Ubuntu 14.04, CUDA 8, old Docker GPU runtime)
+- Continental radar bags use Protobuf messages and are not fully supported
+- Modern GPUs (RTX series) often fail without rebuilding CUDA artifacts
+- No ego-motion compensation, sequence fuser, or planning modules (see [ROADMAP.md](ROADMAP.md))
+
+## Maintenance roadmap
+
+See [ROADMAP.md](ROADMAP.md) for the 2026 plan. Initial focus:
+
+1. License and attribution clarity
+2. Issue triage and documentation
+3. Demo bag and environment matrix
+4. Lightweight CI and contribution guidelines
+
 ## Environment Information
 The system is tested on Nvidia GeForce GTX 1080 Ti and 1070 Max-Q. Please install **Nvidia Driver**, [**Docker**](https://docs.docker.com/install/linux/docker-ce/ubuntu/), and [**Nvidia Docker**](https://github.com/NVIDIA/nvidia-docker).
 
@@ -42,7 +76,7 @@ mkdir ~/shared_dir && cd ~/shared_dir
 git clone https://github.com/cedricxie/apollo_perception_ros
 ```
 
-2. Pull Dokcer Image  
+2. Pull Docker Image  
 ```docker pull cedricxie/apollo-perception-ros```
 
 3. Enter Docker Container  
@@ -63,14 +97,18 @@ source devel/setup.bash
 The bag can be downloaded at [Apollo Data Open Platform](http://data.apollo.auto), Vehicle System Demo Data, with file name ```demo-sensor-data-apollo-2.0.tar.gz```.
 
 ## Known issues
-1. During building process, an error such as follows might occur. Usually do ```catkin build``` again can skip the problem. I am still trying to figure out how to complete solve it. Let me know if you find out a solution.
+1. During building, a C++11 toolchain error may appear. Running `catkin build` again sometimes succeeds. If it persists, verify you are using the provided Docker image and compiler toolchain.
+
 ```
 /usr/include/c++/4.8/bits/c++0x_warning.h:32:2: error: #error This file requires compiler and library support for the ISO C++ 2011 standard. This support is currently experimental, and must be enabled with the -std=c++11 or -std=gnu++11 compiler options.
 ```
 
 2. Continental radar detection messages are in Protobuf format inside the ROS bag. Therefore it is not currently supported. However if you have your own radar, you can utilize the modest radar detector in the perception module to integrate into the system.
 
-## To Do:
-1. Add ego motion compensation.
-2. Add sequence type fuser
-3. Add Prediction / Planning modules.
+## Roadmap
+
+Longer-term technical goals are tracked in [ROADMAP.md](ROADMAP.md), including:
+
+1. Ego motion compensation
+2. Sequence type fuser
+3. Prediction / Planning modules (out of current scope)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,50 @@
+# Roadmap
+
+## Vision
+
+Keep `apollo_perception_ros` useful as an **educational reference** for Apollo 3.0
+perception — with honest documentation, triaged issues, and incremental
+compatibility improvements where feasible.
+
+## 2026 Q3 — Maintenance restart (Phase 1)
+
+- [ ] Add Apache-2.0 LICENSE, NOTICE, third-party notices
+- [ ] Reposition README (status, audience, limitations)
+- [ ] Add CONTRIBUTING.md and SECURITY.md
+- [ ] Triage open issues and add labels
+- [ ] Publish `v0.1.0-historical` release
+- [ ] Document demo bag acquisition and playback
+- [ ] Publish supported environment matrix
+
+## 2026 Q4 — Documentation & CI (Phase 2)
+
+- [ ] Add issue/PR templates
+- [ ] Fix broken documentation links
+- [ ] Add lightweight CI (markdown / shellcheck / repo structure)
+- [ ] Consolidate CUDA / Docker troubleshooting guide
+
+## Future (best-effort)
+
+- [ ] Ego motion compensation
+- [ ] Sequence type fuser
+- [ ] Community sensor adapter examples
+- [ ] Evaluate modernized Docker base image (no guarantee of model compatibility)
+
+## Out of scope
+
+- Full migration to Apollo Cyber RT
+- Production deployment guarantees
+- Supporting every GPU generation without community help
+
+## Codex-assisted maintenance
+
+Maintainer workflows where AI assistance adds value:
+
+- Issue triage and duplicate detection
+- Drafting compatibility documentation from error logs
+- PR review for docs and small fixes
+- Security / dependency hygiene scans
+- Generating reproducible Docker troubleshooting steps
+
+API credits (if granted via Codex for OSS) will be used **only** for these OSS
+maintenance workflows.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -8,10 +8,10 @@ compatibility improvements where feasible.
 
 ## 2026 Q3 — Maintenance restart (Phase 1)
 
-- [ ] Add Apache-2.0 LICENSE, NOTICE, third-party notices
-- [ ] Reposition README (status, audience, limitations)
-- [ ] Add CONTRIBUTING.md and SECURITY.md
-- [ ] Triage open issues and add labels
+- [x] Add Apache-2.0 LICENSE, NOTICE, third-party notices
+- [x] Reposition README (status, audience, limitations)
+- [x] Add CONTRIBUTING.md and SECURITY.md
+- [x] Triage open issues and add labels
 - [ ] Publish `v0.1.0-historical` release
 - [ ] Document demo bag acquisition and playback
 - [ ] Publish supported environment matrix

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -11,7 +11,7 @@ maintenance restart.
 Please report security issues privately:
 
 - GitHub: use **Report a vulnerability** on the Security tab, or
-- Email the maintainer directly (see GitHub profile).
+- Email: cedricxie@gmail.com
 
 Do not open public issues for exploitable vulnerabilities.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,24 @@
+# Security Policy
+
+## Supported versions
+
+This is a historical / educational ROS port of Apollo 3.0 perception. Only the
+current default branch receives best-effort security review during the 2026
+maintenance restart.
+
+## Reporting a vulnerability
+
+Please report security issues privately:
+
+- GitHub: use **Report a vulnerability** on the Security tab, or
+- Email the maintainer directly (see GitHub profile).
+
+Do not open public issues for exploitable vulnerabilities.
+
+## Scope and limitations
+
+- This project is for research and education, not production deployment.
+- Docker images may bundle outdated dependencies; do not expose them to untrusted
+  networks without review.
+- We will acknowledge reports within a reasonable timeframe and patch or document
+  mitigations when feasible.


### PR DESCRIPTION
## Summary
- Reposition README as a historical/educational Apollo 3.0 perception ROS port
- Add `ROADMAP.md`, `CONTRIBUTING.md`, and `SECURITY.md`
- Fix `Dokcer` typo and tighten known-issues wording
- Clarify security contact email and mark shipped Phase 1 roadmap items

Reopened after #28 merged to `master` (supersedes closed #29).

Part of the 2026 maintenance restart (Phase 1, PR 2 of 2).

## Test plan
- [x] README links to LICENSE/NOTICE (from #28)
- [x] ROADMAP reflects shipped Phase 1 docs/licensing work
- [x] SECURITY policy includes maintainer email


Made with [Cursor](https://cursor.com)