### PR TITLE
docs: add known issues and supported environments guides

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Thank you for helping improve this educational Apollo perception port.
 
 ## Before you start
 
-- Read [ROADMAP.md](ROADMAP.md) and [README.md](README.md#known-limitations)
+- Read [ROADMAP.md](ROADMAP.md), [docs/KNOWN_ISSUES.md](docs/KNOWN_ISSUES.md), and [README.md](README.md#known-limitations)
 - Check [open issues](https://github.com/cedricxie/apollo_perception_ros/issues)
 - Prefer Docker-based reproduction when possible
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ It is **not** a production autonomous driving stack.
 
 - Requires a legacy software stack (Ubuntu 14.04, CUDA 8, old Docker GPU runtime); see [docs/SUPPORTED_ENVIRONMENTS.md](docs/SUPPORTED_ENVIRONMENTS.md)
 - Continental radar bags use Protobuf messages and are not fully supported; see [docs/KNOWN_ISSUES.md](docs/KNOWN_ISSUES.md#continental-radar-in-apollo-demo-bag)
-- Modern GPUs (RTX series) often fail without rebuilding CUDA artifacts; see [docs/KNOWN_ISSUES.md](docs/KNOWN_ISSUES.md#invalid-device-function)
+- Modern GPUs (RTX series) often fail without rebuilding CUDA artifacts; see [docs/KNOWN_ISSUES.md](docs/KNOWN_ISSUES.md#cuda-and-gpu-compatibility)
 - No ego-motion compensation, sequence fuser, or planning modules (see [ROADMAP.md](ROADMAP.md))
 
 ## Maintenance roadmap
@@ -103,10 +103,11 @@ See **[docs/DEMO_BAG.md](docs/DEMO_BAG.md)** for download links and setup. The
 original Apollo open data platform (`http://data.apollo.auto`) may be
 unavailable; a verified maintainer mirror is documented there.
 
-## Known issues
+## Related documentation
 
-See **[docs/KNOWN_ISSUES.md](docs/KNOWN_ISSUES.md)** for reported problems,
-workarounds, and links to the corresponding GitHub issues.
+- **[docs/KNOWN_ISSUES.md](docs/KNOWN_ISSUES.md)** — reported problems, workarounds, and links to GitHub issues
+- **[docs/SUPPORTED_ENVIRONMENTS.md](docs/SUPPORTED_ENVIRONMENTS.md)** — reference and unverified environment matrix
+- **[docs/DEMO_BAG.md](docs/DEMO_BAG.md)** — demo bag download and playback
 
 ## Roadmap
 

--- a/README.md
+++ b/README.md
@@ -47,9 +47,9 @@ It is **not** a production autonomous driving stack.
 
 ## Known limitations
 
-- Requires a legacy software stack (Ubuntu 14.04, CUDA 8, old Docker GPU runtime)
-- Continental radar bags use Protobuf messages and are not fully supported
-- Modern GPUs (RTX series) often fail without rebuilding CUDA artifacts
+- Requires a legacy software stack (Ubuntu 14.04, CUDA 8, old Docker GPU runtime); see [docs/SUPPORTED_ENVIRONMENTS.md](docs/SUPPORTED_ENVIRONMENTS.md)
+- Continental radar bags use Protobuf messages and are not fully supported; see [docs/KNOWN_ISSUES.md](docs/KNOWN_ISSUES.md#continental-radar-in-apollo-demo-bag)
+- Modern GPUs (RTX series) often fail without rebuilding CUDA artifacts; see [docs/KNOWN_ISSUES.md](docs/KNOWN_ISSUES.md#invalid-device-function)
 - No ego-motion compensation, sequence fuser, or planning modules (see [ROADMAP.md](ROADMAP.md))
 
 ## Maintenance roadmap
@@ -62,6 +62,10 @@ See [ROADMAP.md](ROADMAP.md) for the 2026 plan. Initial focus:
 4. Lightweight CI and contribution guidelines
 
 ## Environment Information
+
+See [docs/SUPPORTED_ENVIRONMENTS.md](docs/SUPPORTED_ENVIRONMENTS.md) for the
+reference and unverified environment matrix.
+
 The system is tested on Nvidia GeForce GTX 1080 Ti and 1070 Max-Q. Please install **Nvidia Driver**, [**Docker**](https://docs.docker.com/install/linux/docker-ce/ubuntu/), and [**Nvidia Docker**](https://github.com/NVIDIA/nvidia-docker).
 
 | **Dependencies**                  	| Image Environment  	|
@@ -100,13 +104,9 @@ original Apollo open data platform (`http://data.apollo.auto`) may be
 unavailable; a verified maintainer mirror is documented there.
 
 ## Known issues
-1. During building, a C++11 toolchain error may appear. Running `catkin build` again sometimes succeeds. If it persists, verify you are using the provided Docker image and compiler toolchain.
 
-```
-/usr/include/c++/4.8/bits/c++0x_warning.h:32:2: error: #error This file requires compiler and library support for the ISO C++ 2011 standard. This support is currently experimental, and must be enabled with the -std=c++11 or -std=gnu++11 compiler options.
-```
-
-2. Continental radar detection messages are in Protobuf format inside the ROS bag. Therefore it is not currently supported. However if you have your own radar, you can utilize the modest radar detector in the perception module to integrate into the system.
+See **[docs/KNOWN_ISSUES.md](docs/KNOWN_ISSUES.md)** for reported problems,
+workarounds, and links to the corresponding GitHub issues.
 
 ## Roadmap
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -14,14 +14,14 @@ compatibility improvements where feasible.
 - [x] Triage open issues and add labels
 - [x] Publish `v0.1.0-historical` release
 - [x] Document demo bag acquisition and playback
-- [ ] Publish supported environment matrix
+- [x] Publish supported environment matrix
 
 ## 2026 Q4 — Documentation & CI (Phase 2)
 
 - [ ] Add issue/PR templates
 - [ ] Fix broken documentation links
 - [ ] Add lightweight CI (markdown / shellcheck / repo structure)
-- [ ] Consolidate CUDA / Docker troubleshooting guide
+- [x] Consolidate CUDA / Docker troubleshooting guide (`docs/KNOWN_ISSUES.md`)
 
 ## Future (best-effort)
 

--- a/docs/DEMO_BAG.md
+++ b/docs/DEMO_BAG.md
@@ -90,7 +90,7 @@ rosbag play ~/shared_dir/demo-2.0.bag --clock
 | --- | --- |
 | Dropbox link fails | Try the direct-download `dl=1` URL above. If it stops working, comment on issue #26. |
 | Bag not found in container | Confirm the file is under the mounted `shared_dir` path, not only on the host outside the mount. |
-| No perception output | Verify topics with `rostopic list` and check GPU/Docker setup. See README known limitations. |
+| No perception output | Verify topics with `rostopic list` and check GPU/Docker setup. See [KNOWN_ISSUES.md](KNOWN_ISSUES.md) and [SUPPORTED_ENVIRONMENTS.md](SUPPORTED_ENVIRONMENTS.md). |
 | Radar not working | Continental radar messages in the bag use Protobuf and are not fully supported in this port. |
 
 ## Related issues

--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -15,22 +15,41 @@ Related docs:
 
 ## Build and toolchain
 
-### C++11 / catkin build errors
+### C++11 / catkin / ROS environment errors
 
 **Symptoms**
 
 - `#error This file requires compiler and library support for the ISO C++ 2011 standard`
 - Intermittent `catkin build` failures on first attempt
+- `catkin CMake module was not found` or missing `roscppConfig.cmake`
+- Building outside Docker without a sourced ROS environment
 
 **Status:** Known on non-reference toolchains; often transient inside the reference Docker image.
 
 **Workaround**
 
 - Build inside `cedricxie/apollo-perception-ros` Docker
+- Source ROS inside the container before building (e.g. `source /opt/ros/indigo/setup.bash`)
 - Retry `catkin build`
 - Capture the first hard error if warnings are only about deprecated GPU targets
 
-**Reported in:** [#3](https://github.com/cedricxie/apollo_perception_ros/issues/3), [#13](https://github.com/cedricxie/apollo_perception_ros/issues/13)
+**Reported in:** [#3](https://github.com/cedricxie/apollo_perception_ros/issues/3), [#13](https://github.com/cedricxie/apollo_perception_ros/issues/13), [#2](https://github.com/cedricxie/apollo_perception_ros/issues/2)
+
+---
+
+### Eigen version mismatch (historical)
+
+**Symptoms**
+
+- Runtime assertion or crash when starting `perception_yx_node` after a local build
+
+**Status:** Resolved in at least one report by downgrading Eigen (for example from 3.3.90 to 3.2.10).
+
+**Workaround**
+
+- Prefer the reference Docker image rather than mixing host Eigen versions
+
+**Reported in:** [#10](https://github.com/cedricxie/apollo_perception_ros/issues/10) (closed)
 
 ---
 
@@ -64,6 +83,7 @@ Related docs:
 **Workaround**
 
 - Use the provided CUDA 8 Docker workflow rather than porting to CUDA 10+
+- Community report on [#6](https://github.com/cedricxie/apollo_perception_ros/issues/6): adding OpenCV headers to `cuda_util/util.cu` may unblock some CUDA 10 builds, but this is **unverified** and not part of the maintained workflow
 
 **Reported in:** [#6](https://github.com/cedricxie/apollo_perception_ros/issues/6)
 
@@ -132,7 +152,7 @@ Related docs:
 - Unclear where to place or how to play `demo-2.0.bag`
 - Questions about Velodyne-only bags vs Apollo demo bag
 
-**Status:** Documented with a verified maintainer mirror.
+**Status:** Documented with a verified maintainer mirror. This repo is tested with the Apollo 2.0 vehicle demo bag, not arbitrary Velodyne-only bags.
 
 **Workaround**
 
@@ -151,7 +171,7 @@ Related docs:
 - `Cannot transform frame: base_link to frame camera_long`
 - `failed to get trans at timestamp`
 
-**Status:** Usually launch order or `use_sim_time` mismatch.
+**Status:** Usually launch order or `use_sim_time` mismatch. [#11](https://github.com/cedricxie/apollo_perception_ros/issues/11) may also reflect a deeper coordinate-transform bug and remains open.
 
 **Workaround**
 
@@ -169,7 +189,7 @@ Related docs:
 
 - `/perception/output/fusion_velocity_marker` positions are `0`
 
-**Status:** Under investigation; often related to TF/timestamp alignment or incomplete sensor inputs.
+**Status:** Under investigation; often related to TF/timestamp alignment, incomplete sensor inputs, or GPU incompatibility. One report ([#24](https://github.com/cedricxie/apollo_perception_ros/issues/24)) improved after switching from RTX 4000 to GTX 1050 Ti.
 
 **Workaround**
 
@@ -188,15 +208,16 @@ Related docs:
 - `unsupported encoding yuyv`
 - Expectation that LiDAR clustering requires camera input
 
-**Status:** Demo workflow requires both camera and LiDAR topics; image display depends on topic encoding and sim time settings.
+**Status:** Demo workflow requires both camera and LiDAR topics. Camera topics in the Apollo bag may use `yuyv`, which RViz does not display directly; the code path also logs that `yuyv` is not supported for conversion.
 
 **Workaround**
 
 - Use `detect_sim.launch` + `rosbag play ... --clock`
 - See [DEMO_BAG.md](DEMO_BAG.md)
+- Check perception output image topics in RViz instead of the raw bag encoding if needed
 - Share `rostopic list` and camera topic metadata if it persists
 
-**Reported in:** [#16](https://github.com/cedricxie/apollo_perception_ros/issues/16)
+**Reported in:** [#16](https://github.com/cedricxie/apollo_perception_ros/issues/16), [#21](https://github.com/cedricxie/apollo_perception_ros/issues/21) (closed)
 
 ---
 
@@ -207,14 +228,16 @@ Related docs:
 **Symptoms**
 
 - Radar fusion unavailable when playing the stock Apollo demo bag
+- Questions about why radar-related code is commented out
 
-**Status:** Continental radar messages in the bag use Protobuf and are not fully supported in this ROS port.
+**Status:** Continental radar messages in the bag use Protobuf and are not fully supported in this ROS port. By default, `use_radar` is `false` in `perception_yx_detect.launch`, and the Continental radar topic subscription in `perception_yx.cpp` is commented out.
 
 **Workaround**
 
-- Disable radar in launch parameters, or integrate your own radar with the modest radar detector code path
+- Leave radar disabled for the demo bag workflow
+- To experiment with your own radar, use the modest radar detector code path and provide a compatible ROS message source
 
-**Reported in:** [#15](https://github.com/cedricxie/apollo_perception_ros/issues/15#issuecomment-867289918) (radar integration question on a demo-bag thread)
+**Reported in:** [#15](https://github.com/cedricxie/apollo_perception_ros/issues/15#issuecomment-867289918), [#16](https://github.com/cedricxie/apollo_perception_ros/issues/16), [#18](https://github.com/cedricxie/apollo_perception_ros/issues/18)
 
 ---
 
@@ -255,19 +278,21 @@ Related docs:
 
 ## Documentation
 
-### Broken documentation links
+### ROS distro / CMake path confusion
 
 **Symptoms**
 
-- README or docs reference missing paths (e.g. `CMakeLists.txt` link)
+- Confusion about whether the project targets ROS Indigo or Kinetic
+- References to `src/perception/CMakeLists.txt` or Kinetic catkin paths
 
-**Status:** Tracked for cleanup.
+**Status:** The reference workflow is the Ubuntu 14.04 Docker image with the catkin packages under `src/perception/apollo_perception_ros/`. Some older reports used outdated paths or non-reference ROS installs.
 
 **Workaround**
 
-- Open a PR or comment on the issue with the correct target path
+- Use the Docker workflow in the README
+- See [SUPPORTED_ENVIRONMENTS.md](SUPPORTED_ENVIRONMENTS.md)
 
-**Reported in:** [#9](https://github.com/cedricxie/apollo_perception_ros/issues/9)
+**Reported in:** [#9](https://github.com/cedricxie/apollo_perception_ros/issues/9), [#14](https://github.com/cedricxie/apollo_perception_ros/issues/14)
 
 ---
 

--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -53,6 +53,22 @@ Related docs:
 
 ## CUDA and GPU compatibility
 
+### CUDA 10+ build failures
+
+**Symptoms**
+
+- Build fails on CUDA 10 with errors such as `incomplete type is not allowed` in `cuda_util/util.cu`
+
+**Status:** Unsupported. The reference Docker image targets CUDA 8.
+
+**Workaround**
+
+- Use the provided CUDA 8 Docker workflow rather than porting to CUDA 10+
+
+**Reported in:** [#6](https://github.com/cedricxie/apollo_perception_ros/issues/6)
+
+---
+
 ### `invalid device function`
 
 **Symptoms**
@@ -66,7 +82,7 @@ Related docs:
 - Prefer the reference GTX 10-series + CUDA 8 Docker workflow
 - Rebuilding CUDA artifacts for newer GPUs is not part of the reference maintenance path
 
-**Reported in:** [#6](https://github.com/cedricxie/apollo_perception_ros/issues/6), [#18](https://github.com/cedricxie/apollo_perception_ros/issues/18), [#27](https://github.com/cedricxie/apollo_perception_ros/issues/27)
+**Reported in:** [#18](https://github.com/cedricxie/apollo_perception_ros/issues/18), [#27](https://github.com/cedricxie/apollo_perception_ros/issues/27)
 
 ---
 
@@ -198,7 +214,7 @@ Related docs:
 
 - Disable radar in launch parameters, or integrate your own radar with the modest radar detector code path
 
-**Reported in:** Documented limitation (see README). Radar integration questions also appear in [#15](https://github.com/cedricxie/apollo_perception_ros/issues/15#issuecomment-867289918).
+**Reported in:** [#15](https://github.com/cedricxie/apollo_perception_ros/issues/15#issuecomment-867289918) (radar integration question on a demo-bag thread)
 
 ---
 

--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -1,0 +1,261 @@
+# Known Issues
+
+This document consolidates commonly reported problems for `apollo_perception_ros`.
+It is an educational / historical port — many reports reflect environment
+mismatch rather than regressions in current maintenance.
+
+Each item links to the GitHub issue(s) where it was reported.
+
+Related docs:
+
+- [DEMO_BAG.md](DEMO_BAG.md) — demo bag download and playback
+- [SUPPORTED_ENVIRONMENTS.md](SUPPORTED_ENVIRONMENTS.md) — reference and unverified environments
+
+---
+
+## Build and toolchain
+
+### C++11 / catkin build errors
+
+**Symptoms**
+
+- `#error This file requires compiler and library support for the ISO C++ 2011 standard`
+- Intermittent `catkin build` failures on first attempt
+
+**Status:** Known on non-reference toolchains; often transient inside the reference Docker image.
+
+**Workaround**
+
+- Build inside `cedricxie/apollo-perception-ros` Docker
+- Retry `catkin build`
+- Capture the first hard error if warnings are only about deprecated GPU targets
+
+**Reported in:** [#3](https://github.com/cedricxie/apollo_perception_ros/issues/3), [#13](https://github.com/cedricxie/apollo_perception_ros/issues/13)
+
+---
+
+### Missing Caffe layers (`reorg`, `permute`, `roi_pooling`)
+
+**Symptoms**
+
+- `Caffe::LayerParameter` cannot find `reorg` or `roi_pooling`
+- Build fails when using stock Caffe instead of the Apollo-era fork
+
+**Status:** Expected outside the bundled Docker environment.
+
+**Workaround**
+
+- Build inside the provided Docker image, which includes the custom Caffe layers used by this port
+
+**Reported in:** [#23](https://github.com/cedricxie/apollo_perception_ros/issues/23)
+
+---
+
+## CUDA and GPU compatibility
+
+### `invalid device function`
+
+**Symptoms**
+
+- `permute_layer.cu: Check failed: error == cudaSuccess (8 vs. 0) invalid device function`
+
+**Status:** Common on GPUs newer than the original CUDA 8 / SM targets.
+
+**Workaround**
+
+- Prefer the reference GTX 10-series + CUDA 8 Docker workflow
+- Rebuilding CUDA artifacts for newer GPUs is not part of the reference maintenance path
+
+**Reported in:** [#6](https://github.com/cedricxie/apollo_perception_ros/issues/6), [#18](https://github.com/cedricxie/apollo_perception_ros/issues/18), [#27](https://github.com/cedricxie/apollo_perception_ros/issues/27)
+
+---
+
+## Docker and NVIDIA runtime
+
+### `Unknown runtime specified nvidia`
+
+**Symptoms**
+
+- Docker fails to start the container with an unknown `nvidia` runtime
+
+**Status:** Host/runtime configuration issue.
+
+**Workaround**
+
+- Install NVIDIA Container Toolkit
+- Avoid legacy `nvidia-docker` v1-only setups
+
+**Reported in:** [#1](https://github.com/cedricxie/apollo_perception_ros/issues/1)
+
+---
+
+### `nvml error: driver not loaded`
+
+**Symptoms**
+
+- `nvidia-container-cli: initialization error: nvml error: driver not loaded: unknown`
+
+**Status:** Host NVIDIA driver not visible to Docker.
+
+**Workaround**
+
+- Verify `nvidia-smi` on the host
+- Confirm GPU flags/runtime are passed to `docker run`
+
+**Reported in:** [#20](https://github.com/cedricxie/apollo_perception_ros/issues/20)
+
+---
+
+## Demo bag and sensor data
+
+### Demo bag download / playback
+
+**Symptoms**
+
+- Apollo open data platform link unavailable
+- Unclear where to place or how to play `demo-2.0.bag`
+- Questions about Velodyne-only bags vs Apollo demo bag
+
+**Status:** Documented with a verified maintainer mirror.
+
+**Workaround**
+
+- Follow [DEMO_BAG.md](DEMO_BAG.md)
+
+**Reported in:** [#15](https://github.com/cedricxie/apollo_perception_ros/issues/15), [#19](https://github.com/cedricxie/apollo_perception_ros/issues/19), [#25](https://github.com/cedricxie/apollo_perception_ros/issues/25), [#26](https://github.com/cedricxie/apollo_perception_ros/issues/26)
+
+---
+
+## TF, coordinates, and visualization
+
+### Missing `base_link` / `camera_long` transforms
+
+**Symptoms**
+
+- `Cannot transform frame: base_link to frame camera_long`
+- `failed to get trans at timestamp`
+
+**Status:** Usually launch order or `use_sim_time` mismatch.
+
+**Workaround**
+
+1. `roslaunch vehicle_base detect_sim.launch`
+2. `rosbag play ~/shared_dir/demo-2.0.bag --clock`
+3. Inspect TF tree with `rqt_tf_tree` or `tf_monitor`
+
+**Reported in:** [#11](https://github.com/cedricxie/apollo_perception_ros/issues/11), [#22](https://github.com/cedricxie/apollo_perception_ros/issues/22)
+
+---
+
+### Fusion velocity markers show zeros
+
+**Symptoms**
+
+- `/perception/output/fusion_velocity_marker` positions are `0`
+
+**Status:** Under investigation; often related to TF/timestamp alignment or incomplete sensor inputs.
+
+**Workaround**
+
+- Confirm camera + LiDAR topics are present from the demo bag
+- Verify TF tree and `use_sim_time`
+
+**Reported in:** [#24](https://github.com/cedricxie/apollo_perception_ros/issues/24)
+
+---
+
+### RViz image / encoding issues during demo playback
+
+**Symptoms**
+
+- No images in RViz
+- `unsupported encoding yuyv`
+- Expectation that LiDAR clustering requires camera input
+
+**Status:** Demo workflow requires both camera and LiDAR topics; image display depends on topic encoding and sim time settings.
+
+**Workaround**
+
+- Use `detect_sim.launch` + `rosbag play ... --clock`
+- See [DEMO_BAG.md](DEMO_BAG.md)
+- Share `rostopic list` and camera topic metadata if it persists
+
+**Reported in:** [#16](https://github.com/cedricxie/apollo_perception_ros/issues/16)
+
+---
+
+## Radar
+
+### Continental radar in Apollo demo bag
+
+**Symptoms**
+
+- Radar fusion unavailable when playing the stock Apollo demo bag
+
+**Status:** Continental radar messages in the bag use Protobuf and are not fully supported in this ROS port.
+
+**Workaround**
+
+- Disable radar in launch parameters, or integrate your own radar with the modest radar detector code path
+
+**Reported in:** Documented limitation (see README). Radar integration questions also appear in [#15](https://github.com/cedricxie/apollo_perception_ros/issues/15#issuecomment-867289918).
+
+---
+
+## Environment and platform support
+
+### ROS Kinetic / Ubuntu 16.04
+
+**Symptoms**
+
+- VTK5 vs VTK6 / PCL build conflicts when porting off the reference image
+
+**Status:** Community/unverified.
+
+**Workaround**
+
+- Use the reference Ubuntu 14.04 Docker workflow in the README
+
+**Reported in:** [#14](https://github.com/cedricxie/apollo_perception_ros/issues/14)
+
+---
+
+### Hardware requirements and Docker usage
+
+**Symptoms**
+
+- Questions about required GPU/hardware
+- Whether Docker is mandatory
+
+**Status:** Documented at a high level.
+
+**Workaround**
+
+- See [SUPPORTED_ENVIRONMENTS.md](SUPPORTED_ENVIRONMENTS.md)
+
+**Reported in:** [#4](https://github.com/cedricxie/apollo_perception_ros/issues/4), [#5](https://github.com/cedricxie/apollo_perception_ros/issues/5)
+
+---
+
+## Documentation
+
+### Broken documentation links
+
+**Symptoms**
+
+- README or docs reference missing paths (e.g. `CMakeLists.txt` link)
+
+**Status:** Tracked for cleanup.
+
+**Workaround**
+
+- Open a PR or comment on the issue with the correct target path
+
+**Reported in:** [#9](https://github.com/cedricxie/apollo_perception_ros/issues/9)
+
+---
+
+## Reporting a new issue
+
+Before opening a duplicate, search [open issues](https://github.com/cedricxie/apollo_perception_ros/issues).
+Include GPU model, driver version, OS, Docker command, and logs.

--- a/docs/SUPPORTED_ENVIRONMENTS.md
+++ b/docs/SUPPORTED_ENVIRONMENTS.md
@@ -1,0 +1,48 @@
+# Supported Environments
+
+This project is a **historical / educational** ROS port of Apollo 3.0 perception.
+Only the environment below is treated as the reference configuration.
+
+For common failures on other setups, see [KNOWN_ISSUES.md](KNOWN_ISSUES.md).
+
+## Reference environment (tested originally)
+
+| Component | Version / hardware |
+| --- | --- |
+| Host GPU | NVIDIA GeForce GTX 1080 Ti, GTX 1070 Max-Q |
+| NVIDIA driver | 384.130 (historical) |
+| Container OS | Ubuntu 14.04 |
+| CUDA | 8.0 |
+| cuDNN | 7 |
+| ROS workflow | catkin inside provided Docker image |
+| GPU runtime | `nvidia-docker` v2 era / NVIDIA Container Toolkit equivalent |
+| Docker image | `cedricxie/apollo-perception-ros` |
+
+## Community / unverified environments
+
+| Environment | Status | Notes |
+| --- | --- | --- |
+| Ubuntu 18.04 / 20.04 | Unverified | May require Docker image rebuild |
+| ROS Kinetic on Ubuntu 16.04 | Unverified | VTK/PCL conflicts reported ([#14](https://github.com/cedricxie/apollo_perception_ros/issues/14)) |
+| CUDA 10+ | Unsupported | Reference image targets CUDA 8 ([#6](https://github.com/cedricxie/apollo_perception_ros/issues/6)) |
+| NVIDIA RTX 20xx / 30xx / 40xx | Likely broken | `invalid device function` without CUDA rebuild ([#18](https://github.com/cedricxie/apollo_perception_ros/issues/18), [#27](https://github.com/cedricxie/apollo_perception_ros/issues/27)) |
+| Builds outside provided Docker | Unverified | Custom Caffe/CUDA layers may be missing ([#23](https://github.com/cedricxie/apollo_perception_ros/issues/23)) |
+| Legacy `nvidia-docker` v1 only | Deprecated | Use NVIDIA Container Toolkit ([#1](https://github.com/cedricxie/apollo_perception_ros/issues/1)) |
+
+## Recommended workflow
+
+1. Install NVIDIA driver on the host and verify `nvidia-smi`
+2. Install Docker and NVIDIA Container Toolkit
+3. Pull and run `cedricxie/apollo-perception-ros`
+4. Build with `catkin build` inside the container
+5. Use `demo-2.0.bag` per [DEMO_BAG.md](DEMO_BAG.md)
+
+## Hardware questions
+
+General hardware expectations are discussed in
+[#5](https://github.com/cedricxie/apollo_perception_ros/issues/5).
+Docker is strongly recommended but not theoretically mandatory
+ ([#4](https://github.com/cedricxie/apollo_perception_ros/issues/4)).
+
+If your setup differs, please open an issue with GPU model, driver version, OS,
+Docker command, and build/runtime logs.

--- a/docs/SUPPORTED_ENVIRONMENTS.md
+++ b/docs/SUPPORTED_ENVIRONMENTS.md
@@ -41,8 +41,7 @@ For common failures on other setups, see [KNOWN_ISSUES.md](KNOWN_ISSUES.md).
 
 General hardware expectations are discussed in
 [#5](https://github.com/cedricxie/apollo_perception_ros/issues/5).
-Docker is strongly recommended but not theoretically mandatory
- ([#4](https://github.com/cedricxie/apollo_perception_ros/issues/4)).
+Docker is strongly recommended but not theoretically mandatory ([#4](https://github.com/cedricxie/apollo_perception_ros/issues/4)).
 
 If your setup differs, please open an issue with GPU model, driver version, OS,
 Docker command, and build/runtime logs.


### PR DESCRIPTION
## Summary
- Add `docs/KNOWN_ISSUES.md` grouping reported problems with workarounds and links to all relevant GitHub issues
- Add `docs/SUPPORTED_ENVIRONMENTS.md` for reference and unverified environment matrix
- Move README known issues into the new guide and cross-link from README, CONTRIBUTING, DEMO_BAG, and ROADMAP

## Test plan
- [x] Every open issue category is represented in KNOWN_ISSUES.md
- [x] README no longer duplicates long known-issue prose
- [x] Internal doc links resolve within `docs/`


Made with [Cursor](https://cursor.com)